### PR TITLE
feat: add save confirmation modal and diff preview, enhance token display with username, and fix access issues for shared configs history

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to SunnyTune are documented here.
 
 ---
 
+## [2.2.2] — 2026-04-07
+
+### Added
+
+- **Save confirmation modal** — clicking Save now opens a confirmation dialog showing the config name, version, and a "View what will change" button that opens a full parameter-level diff of your pending edits against the last saved version; the save only fires once confirmed
+- **Username in token pill** — when a display name is set, it appears inside the token button in the top-right header (desktop and mobile) alongside the truncated token, so the active account is always visible at a glance
+
+### Fixed
+
+- **Version history 403 on shared config pages** — the History modal now correctly loads snapshots for all users when the config is publicly shared; previously non-owners always received a `403 Access Denied` even though the History button was visible
+- **False "Unsaved changes" dialog on first save** — navigating away immediately after saving a brand-new config no longer triggers the navigation guard; the URL update now waits until React has committed `isDirty: false` before changing the route
+
+---
+
 ## [2.2.1] — 2026-04-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Live](https://img.shields.io/badge/Live-sunny--tune.vercel.app-black?logo=vercel&logoColor=white)](https://sunny-tune.vercel.app)
 [![API](https://img.shields.io/badge/API-Railway-7B2FBE?logo=railway&logoColor=white)](https://railway.app)
-[![Version](https://img.shields.io/badge/version-2.2.0-blue)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.2.2-blue)](CHANGELOG.md)
 
 [![Node.js](https://img.shields.io/badge/Node.js-20%2B-brightgreen?logo=node.js&logoColor=white)](https://nodejs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.4-3178C6?logo=typescript&logoColor=white)](https://www.typescriptlang.org/)

--- a/client/src/components/config/ConfigHistoryModal.tsx
+++ b/client/src/components/config/ConfigHistoryModal.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { ArrowLeftRight } from "lucide-react";
+import { AlertCircle, ArrowLeftRight } from "lucide-react";
 import React, { useState } from "react";
 import { fetchConfigHistory, fetchConfigSnapshot } from "../../api";
 import type { ConfigSnapshotMeta, SPConfig } from "../../types/config";
@@ -33,7 +33,7 @@ export const ConfigHistoryModal: React.FC<ConfigHistoryModalProps> = ({
     useState<ConfigSnapshotMeta | null>(null);
   const [diffOpen, setDiffOpen] = useState(false);
 
-  const { data: historyList = [] } = useQuery({
+  const { data: historyList = [], isError: historyError } = useQuery({
     queryKey: ["config-history", configId],
     queryFn: () => fetchConfigHistory(configId),
     enabled: open,
@@ -60,7 +60,14 @@ export const ConfigHistoryModal: React.FC<ConfigHistoryModalProps> = ({
         width="md"
       >
         <div className="space-y-2">
-          {historyList.length === 0 && (
+          {historyError && (
+            <div className="flex items-center gap-2 p-3 bg-red-500/10 border border-red-500/20 rounded-lg text-xs text-red-400">
+              <AlertCircle className="w-4 h-4 flex-shrink-0" />
+              Failed to load version history. Make sure you are logged in as the
+              config owner or that the config is shared publicly.
+            </div>
+          )}
+          {!historyError && historyList.length === 0 && (
             <p className="text-sm text-zinc-500 py-4 text-center">
               No snapshots yet. Snapshots are saved automatically each time you
               save the config.

--- a/client/src/components/layout/Header.tsx
+++ b/client/src/components/layout/Header.tsx
@@ -395,6 +395,11 @@ export const Header: React.FC = () => {
                          px-2.5 py-1.5 rounded-md transition-colors"
             >
               <KeyRound className="w-3 h-3" />
+              {user?.username && (
+                <span className="font-sans text-zinc-300 font-medium mr-0.5">
+                  {user.username}
+                </span>
+              )}
               {token ? token.slice(0, 14) + "…" : "No token"}
               <ChevronDown className="w-3 h-3 text-zinc-600" />
             </button>
@@ -479,8 +484,15 @@ export const Header: React.FC = () => {
                 className="flex items-center gap-3 w-full px-3 py-2.5 rounded-lg text-sm text-zinc-500 hover:text-zinc-300 hover:bg-zinc-900 transition-colors"
               >
                 <KeyRound className="w-4 h-4 flex-shrink-0" />
-                <span className="font-mono text-xs truncate">
-                  {token ? token.slice(0, 20) + "…" : "No token"}
+                <span className="flex items-center gap-1.5 min-w-0">
+                  {user?.username && (
+                    <span className="font-sans font-medium text-zinc-300 text-xs truncate">
+                      {user.username}
+                    </span>
+                  )}
+                  <span className="font-mono text-xs truncate">
+                    {token ? token.slice(0, 20) + "…" : "No token"}
+                  </span>
                 </span>
               </button>
             </div>

--- a/client/src/lib/version.ts
+++ b/client/src/lib/version.ts
@@ -1,2 +1,2 @@
 /** Current app version — keep in sync with the latest entry in ChangelogPage. */
-export const APP_VERSION = "2.2.1";
+export const APP_VERSION = "2.2.2";

--- a/client/src/pages/ChangelogPage.tsx
+++ b/client/src/pages/ChangelogPage.tsx
@@ -11,6 +11,29 @@ interface Release {
 
 const RELEASES: Release[] = [
   {
+    version: "2.2.2",
+    date: "2026-04-07",
+    tags: ["feature", "fix", "ux"],
+    changes: [
+      {
+        type: "fixed",
+        text: "Version history (History modal) now loads correctly for all users on shared config pages — previously returned 403 Access Denied for non-owners even when the config was publicly shared",
+      },
+      {
+        type: "fixed",
+        text: "Saving a new config for the first time no longer immediately triggers the 'Unsaved changes' navigation guard — navigation now waits until React has committed the clean state before the URL changes",
+      },
+      {
+        type: "added",
+        text: "Save confirmation modal — clicking Save now shows a confirmation dialog with the config name, version, and a 'View what will change' button that opens a full parameter diff against the last saved version before committing",
+      },
+      {
+        type: "added",
+        text: "Username shown in the token pill — when a display name is set, it appears inside the token button in the top-right header (both desktop and mobile) so you always know which account is active",
+      },
+    ],
+  },
+  {
     version: "2.2.1",
     date: "2026-04-06",
     tags: ["feature", "ux"],

--- a/client/src/pages/ConfiguratorPage.tsx
+++ b/client/src/pages/ConfiguratorPage.tsx
@@ -20,6 +20,7 @@ import {
 import { useEffect, useRef, useState } from "react";
 import { useBlocker, useNavigate, useParams } from "react-router-dom";
 import { createConfig, fetchConfig, updateConfig } from "../api";
+import { ConfigDiffModal } from "../components/config/ConfigDiffModal";
 import { ConfigHistoryModal } from "../components/config/ConfigHistoryModal";
 import { ShareModal } from "../components/config/ShareModal";
 import { SunnyLinkExportModal } from "../components/config/SunnyLinkExportModal";
@@ -79,6 +80,8 @@ export default function ConfiguratorPage() {
   const [importError, setImportError] = useState<string | null>(null);
   const [historyOpen, setHistoryOpen] = useState(false);
   const [sunnyLinkExportOpen, setSunnyLinkExportOpen] = useState(false);
+  const [saveConfirmOpen, setSaveConfirmOpen] = useState(false);
+  const [saveConfirmDiffOpen, setSaveConfirmDiffOpen] = useState(false);
 
   // Block in-app SPA navigation when there are unsaved changes
   const blocker = useBlocker(
@@ -161,7 +164,12 @@ export default function ConfiguratorPage() {
         // My Configs page now that the version has (potentially) bumped.
         unmarkSeen(editingId);
       } else {
-        navigate(`/configure/${data.id}`, { replace: true });
+        // Defer navigation until after React re-renders with isDirty=false so
+        // the useBlocker closure sees the clean state and does not fire.
+        setTimeout(
+          () => navigate(`/configure/${data.id}`, { replace: true }),
+          0,
+        );
       }
     },
   });
@@ -315,7 +323,7 @@ export default function ConfiguratorPage() {
                 leftIcon={<Save className="w-3.5 h-3.5" />}
                 loading={saveMutation.isPending}
                 disabled={!isDirty && !!editingId}
-                onClick={() => saveMutation.mutate()}
+                onClick={() => setSaveConfirmOpen(true)}
               >
                 Save
               </Button>
@@ -430,6 +438,90 @@ export default function ConfiguratorPage() {
           config={editingConfig}
           name={editingName}
           onClose={() => setSunnyLinkExportOpen(false)}
+        />
+      )}
+
+      {/* Save confirmation modal */}
+      <Modal
+        open={saveConfirmOpen}
+        onClose={() => {
+          setSaveConfirmOpen(false);
+          setSaveConfirmDiffOpen(false);
+        }}
+        title="Confirm save"
+        width="md"
+      >
+        <div className="space-y-4">
+          <div className="space-y-1 text-sm text-zinc-300">
+            <p>
+              <span className="text-zinc-500">Config:</span>{" "}
+              <span className="font-medium">{editingName}</span>
+            </p>
+            {!editingId && (
+              <p className="text-xs text-zinc-500">
+                This will create a new config.
+              </p>
+            )}
+            {editingId && existingConfig && (
+              <p className="text-xs text-zinc-500">
+                This will overwrite version{" "}
+                <span className="font-mono text-zinc-400">
+                  v{existingConfig.version}
+                </span>{" "}
+                and save a new snapshot.
+              </p>
+            )}
+          </div>
+
+          {/* Show diff button if editing an existing config */}
+          {editingId && existingConfig && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setSaveConfirmDiffOpen(true)}
+              className="w-full justify-center border border-zinc-800"
+            >
+              View what will change
+            </Button>
+          )}
+
+          <div className="flex gap-2 justify-end">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                setSaveConfirmOpen(false);
+                setSaveConfirmDiffOpen(false);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="primary"
+              size="sm"
+              leftIcon={<Save className="w-3.5 h-3.5" />}
+              loading={saveMutation.isPending}
+              onClick={() => {
+                setSaveConfirmOpen(false);
+                setSaveConfirmDiffOpen(false);
+                saveMutation.mutate();
+              }}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      </Modal>
+
+      {/* Save diff preview — what will change vs. the server copy */}
+      {editingId && existingConfig && (
+        <ConfigDiffModal
+          open={saveConfirmDiffOpen}
+          onClose={() => setSaveConfirmDiffOpen(false)}
+          original={existingConfig.config}
+          modified={editingConfig}
+          originalName={`Saved (v${existingConfig.version})`}
+          modifiedName="Your changes"
         />
       )}
 

--- a/client/src/pages/DocsPage.tsx
+++ b/client/src/pages/DocsPage.tsx
@@ -277,6 +277,17 @@ const CONTENT: Record<string, DocBlock[]> = {
             If you navigate away before saving, a confirmation dialog will
             appear. Your browser will also warn you on tab close or refresh.
           </P>
+          <H3>Save confirmation & diff preview</H3>
+          <P>
+            Clicking <strong className="text-zinc-200">Save</strong> opens a
+            confirmation modal before any data is written. The modal shows the
+            config name and version, and a{" "}
+            <strong className="text-zinc-200">View what will change</strong>{" "}
+            button that opens a full parameter-level diff comparing your current
+            edits to the last saved version. The save only fires once you click{" "}
+            <strong className="text-zinc-200">Save</strong> in the confirmation
+            dialog.
+          </P>
           <H3>Import / Export</H3>
           <P>
             Use the <strong className="text-zinc-200">Import</strong> button to
@@ -533,8 +544,9 @@ const CONTENT: Record<string, DocBlock[]> = {
           <P>
             Click the <strong className="text-zinc-200">History</strong> button
             (clock icon) on any config card in My Configs, on the shared config
-            page (accessible by all users), or in the config editor top bar. A
-            modal lists all saved snapshots in reverse-version order.
+            page (accessible to all users — owner and visitors alike), or in the
+            config editor top bar. A modal lists all saved snapshots in
+            reverse-version order.
           </P>
           <H3>Comparing snapshots</H3>
           <P>
@@ -637,7 +649,9 @@ const CONTENT: Record<string, DocBlock[]> = {
           <P>
             Click the key icon (token pill) in the header to open the Token
             modal. It shows your display name, full token, user ID, config
-            count, and member-since date.
+            count, and member-since date. When a display name is set, it also
+            appears directly in the token pill button in the header so your
+            active account is always visible at a glance.
           </P>
           <H3>Importing a token from another device</H3>
           <P>

--- a/server/src/routes/configs.ts
+++ b/server/src/routes/configs.ts
@@ -477,13 +477,14 @@ configsRouter.get(
     try {
       const existing = await prisma.configuration.findUnique({
         where: { id: req.params.id },
-        select: { userId: true },
+        select: { userId: true, isShared: true },
       });
       if (!existing) {
         res.status(404).json({ error: "Configuration not found" });
         return;
       }
-      if (existing.userId !== req.userId) {
+      // Allow access for the owner OR for any authenticated user if the config is publicly shared
+      if (existing.userId !== req.userId && !existing.isShared) {
         res.status(403).json({ error: "Access denied" });
         return;
       }
@@ -508,13 +509,14 @@ configsRouter.get(
     try {
       const existing = await prisma.configuration.findUnique({
         where: { id: req.params.id },
-        select: { userId: true },
+        select: { userId: true, isShared: true },
       });
       if (!existing) {
         res.status(404).json({ error: "Configuration not found" });
         return;
       }
-      if (existing.userId !== req.userId) {
+      // Allow access for the owner OR for any authenticated user if the config is publicly shared
+      if (existing.userId !== req.userId && !existing.isShared) {
         res.status(403).json({ error: "Access denied" });
         return;
       }


### PR DESCRIPTION
## Type of change

- [X] Bug fix (non-breaking)
- [X] New feature (non-breaking)
- [ ] Breaking change (changes existing behaviour)
- [ ] Refactor / code quality
- [X] Documentation
- [ ] CI / build / tooling
- [ ] Dependency update
- [ ] Database migration (changes `schema.prisma`)

---

## Checklist

- [X] I have run `npm test` and all tests pass
- [X] I have run `npx tsc --noEmit` in both `server/` and `client/` — 0 errors
- [ ] If I changed `schema.prisma`, I created and committed a new migration file
- [ ] If I added a new SP/Comma AI parameter, I updated `featureRegistry.ts`, `config.ts`, and `configStore.ts`
- [X] My changes do not introduce secrets, tokens, or credentials into the source code
- [ ] I have added/updated tests where appropriate

---